### PR TITLE
test(core,mtl): Add property-based tests for temporal logic evaluators

### DIFF
--- a/packages/temporal_logic_core/pubspec.yaml
+++ b/packages/temporal_logic_core/pubspec.yaml
@@ -16,5 +16,6 @@ dependencies:
 dev_dependencies:
   test: ^1.25.15
   lints: ^5.1.1
+  glados: ^1.1.7
 
 resolution: workspace

--- a/packages/temporal_logic_core/test/evaluator_test.dart
+++ b/packages/temporal_logic_core/test/evaluator_test.dart
@@ -466,6 +466,168 @@ void main() {
     });
   });
 
+  group('evaluateTrace - Nested Until', () {
+    // (a U b) U c
+    test('(a U b) U c - c holds immediately', () {
+      // Trace: [1, 2, 3]
+      final trace = Trace.fromList([1, 2, 3]);
+      final a = pFalse; // doesn't matter since c holds immediately
+      final b = pFalse;
+      final c = pTrue; // holds at index 0
+      final formula = until(until(a, b), c);
+      // c holds immediately, so outer Until succeeds regardless of inner
+      expect(evaluateTrace(trace, formula, startIndex: 0), _isSuccess());
+    });
+
+    test('(a U b) U c - inner holds but c never holds', () {
+      // Trace: [0, 1, 2, 3]
+      final trace = Trace.fromList([0, 1, 2, 3]);
+      // inner: pEven U pPos -> pPos holds at index 1, pEven holds at index 0 -> inner holds at 0
+      // outer: (pEven U pPos) U pFalse -> right (pFalse) never holds
+      final formula = until(until(pEven, pPos), pFalse);
+      expect(evaluateTrace(trace, formula, startIndex: 0),
+          _isFailure(reason: contains('Right operand never held')));
+    });
+
+    test('(a U b) U c - inner fails, c holds later', () {
+      // Trace: [1, 3, 0, 2]
+      final trace = Trace.fromList([1, 3, 0, 2]);
+      // inner: pEven U pZero -> pZero at idx 2, but pEven fails at idx 0 (1 is odd)
+      // outer: (inner) U pEven -> pEven at idx 3 (2 is even)
+      // For outer Until: need (inner) to hold at idx 0, 1, 2.
+      // inner at 0: pEven U pZero fails (pEven fails at 0)
+      // So outer fails at index 0 (left failed before right held)
+      final formula = until(until(pEven, pZero), pEven);
+      expect(evaluateTrace(trace, formula, startIndex: 0), _isFailure());
+    });
+
+    test('(a U b) U c - neither inner nor c holds', () {
+      final trace = Trace.fromList([1, 3, 5]);
+      // inner: pEven U pZero -> pEven fails at 0, pZero never holds
+      // outer: (inner) U pFalse -> inner fails, pFalse never holds
+      final formula = until(until(pEven, pZero), pFalse);
+      expect(evaluateTrace(trace, formula, startIndex: 0), _isFailure());
+    });
+  });
+
+  group('evaluateTrace - Release Combinations', () {
+    test('(p R q) R r - nested release', () {
+      // Trace: [2, 4, 6] (all even, all positive)
+      final trace = Trace.fromList([2, 4, 6]);
+      // inner: pFalse R pTrue -> !(pTrue U pFalse) -> !(F) -> T
+      // outer: (inner) R pEven -> !(!(inner) U !pEven) -> !(!T U !pEven) -> !(pFalse U pOdd) -> !(F) -> T
+      final formula = Release(Release(pFalse, pTrue), pEven);
+      expect(evaluateTrace(trace, formula, startIndex: 0), _isSuccess());
+    });
+
+    test('(p R q) U r - release then until', () {
+      // Trace: [2, 4, 0, 3]
+      final trace = Trace.fromList([2, 4, 0, 3]);
+      // inner: pFalse R pEven -> !(pTrue U Not(pEven)) -> pTrue U pOdd
+      // pOdd holds at 3 (idx 3), pTrue holds until then -> Until holds -> Not(Until) = false
+      // inner is false. So (inner) U pZero -> left (inner) fails at idx 0
+      final formula = until(Release(pFalse, pEven), pZero);
+      expect(evaluateTrace(trace, formula, startIndex: 0), _isFailure());
+    });
+
+    test('p U (q R r)', () {
+      // Trace: [1, 2, 4, 6]
+      final trace = Trace.fromList([1, 2, 4, 6]);
+      // inner: pFalse R pEven -> !(pTrue U pOdd) -> on suffix starting at some k
+      // At idx 1: pOdd never holds from idx 1 on (2,4,6 all even) -> Until fails -> Release holds
+      // outer: pPos U (pFalse R pEven) -> inner holds at idx 1, pPos at idx 0 -> T
+      final formula = until(pPos, Release(pFalse, pEven));
+      expect(evaluateTrace(trace, formula, startIndex: 0), _isSuccess());
+    });
+  });
+
+  group('evaluateTrace - Deeply Nested Temporal', () {
+    test('G(F(G(p))) - stable true tail', () {
+      // Trace: [1, 0, 0, 0, 0]
+      final trace = Trace.fromList([1, 0, 0, 0, 0]);
+      // G(F(G(pZero))): For each index i, F(G(pZero)) must hold.
+      // At idx 0: F(G(pZero)) -> G(pZero) at idx 1: all 0s from 1 onward -> holds
+      // At idx 1: G(pZero) at idx 1 holds
+      // At idx 2-4: G(pZero) from idx 2-4 holds
+      expect(evaluateTrace(trace, always(eventually(always(pZero))), startIndex: 0), _isSuccess());
+    });
+
+    test('G(F(G(p))) - false last state', () {
+      // Trace: [0, 0, 0, 1]
+      final trace = Trace.fromList([0, 0, 0, 1]);
+      // G(F(G(pZero))): At idx 3: F(G(pZero)) -> G(pZero) at 3 fails (1 != 0) -> F fails
+      // G fails at idx 3
+      expect(evaluateTrace(trace, always(eventually(always(pZero))), startIndex: 0), _isFailure());
+    });
+
+    test('F(G(F(p))) - alternating', () {
+      // Trace: [1, 0, 1, 0, 1]
+      final trace = Trace.fromList([1, 0, 1, 0, 1]);
+      // F(G(F(pZero))): Need G(F(pZero)) from some index.
+      // G(F(pZero)) at idx 0: F(pZero) at each idx.
+      //   idx 0: pZero at 1 -> T. idx 1: pZero at 1 -> T. idx 2: pZero at 3 -> T.
+      //   idx 3: pZero at 3 -> T. idx 4: F(pZero) at 4 -> pZero never holds from 4 (val=1) -> F
+      // G(F(pZero)) at 0 fails.
+      // Try G(F(pZero)) at idx 1: F(pZero) at 1(T), 2(at 3, T), 3(T), 4(F) -> fails
+      // Never holds -> F(G(F(pZero))) = false
+      expect(evaluateTrace(trace, eventually(always(eventually(pZero))), startIndex: 0), _isFailure());
+    });
+
+    test('F(G(F(p))) - eventually becomes recurring', () {
+      // Trace: [1, 1, 0, 1, 0]
+      final trace = Trace.fromList([1, 1, 0, 1, 0]);
+      // G(F(pZero)) from idx 2: F(pZero) at 2(T), 3(at 4, T), 4(T) -> all hold
+      // F(G(F(pZero))) holds at idx 2
+      expect(evaluateTrace(trace, eventually(always(eventually(pZero))), startIndex: 0), _isSuccess());
+    });
+  });
+
+  group('evaluateTrace - Mixed Binary Operators', () {
+    test('(p && q) U r', () {
+      // Trace: [2, 4, 0, 3] -> [even&!pos, even&pos, even&zero, odd&pos]
+      final trace = Trace.fromList([2, 4, 0, 3]);
+      // (pEven && pPos) U pZero
+      // pZero at idx 2. (pEven && pPos) at idx 0: 2 is even, 2 > 0 -> T.
+      // At idx 1: 4 is even, 4 > 0 -> T. Left holds until idx 2.
+      final formula = until(And(pEven, pPos), pZero);
+      expect(evaluateTrace(trace, formula, startIndex: 0), _isSuccess());
+    });
+
+    test('(p && q) U r - left fails early', () {
+      // Trace: [1, 4, 0, 3]
+      final trace = Trace.fromList([1, 4, 0, 3]);
+      // (pEven && pPos) U pZero
+      // pZero at idx 2. (pEven && pPos) at idx 0: 1 is odd -> fails
+      final formula = until(And(pEven, pPos), pZero);
+      expect(evaluateTrace(trace, formula, startIndex: 0), _isFailure());
+    });
+
+    test('(p || q) R r', () {
+      // Trace: [2, 4, 6] (all even, all positive)
+      final trace = Trace.fromList([2, 4, 6]);
+      // (pPos || pZero) R pEven
+      // Release = !(!left U !right) = !(!(pPos||pZero) U !pEven)
+      // !(pPos||pZero) at any idx: all are positive, so Or holds, Not fails.
+      // !(pPos||pZero) is false at every idx -> Until fails (left never holds) -> Release = true
+      final formula = Release(Or(pPos, pZero), pEven);
+      expect(evaluateTrace(trace, formula, startIndex: 0), _isSuccess());
+    });
+
+    test('(p || q) R r - r fails', () {
+      // Trace: [2, 3, 4]
+      final trace = Trace.fromList([2, 3, 4]);
+      // (pZero || pFalse) R pEven
+      // Release = !(!left U !right) = !(!(pZero||pFalse) U !pEven)
+      // !(pZero||pFalse): at 0: pZero=F, pFalse=F -> Or=F, Not=T.
+      //                  at 1: pZero=F, pFalse=F -> Or=F, Not=T.
+      // !pEven: at 0: F (2 is even). at 1: T (3 is odd). at 2: F (4 is even).
+      // Until: Not(Or) U Not(pEven) -> T at 0, T at 1; Not(pEven) at 1 -> Until holds
+      // Release = !true = false
+      final formula = Release(Or(pZero, pFalse), pEven);
+      expect(evaluateTrace(trace, formula, startIndex: 0), _isFailure());
+    });
+  });
+
   group('evaluateTrace - Bug Reproduction Cases', () {
     // --- LTL Propositions ---
     final isLoading = state<MinimalSnap>((s) => s.isLoading, name: 'isLoading');

--- a/packages/temporal_logic_core/test/generators.dart
+++ b/packages/temporal_logic_core/test/generators.dart
@@ -1,0 +1,110 @@
+import 'package:glados/glados.dart';
+import 'package:temporal_logic_core/temporal_logic_core.dart';
+
+// Fixed atomic propositions covering 5 reachable truth patterns over int:
+//  -2: pEven=T, pPos=F, pZero=F
+//  -1: pEven=F, pPos=F, pZero=F
+//   0: pEven=T, pPos=F, pZero=T
+//   1: pEven=F, pPos=T, pZero=F
+//   2: pEven=T, pPos=T, pZero=F
+final pEven = state<int>((n) => n % 2 == 0, name: 'pEven');
+final pPos = state<int>((n) => n > 0, name: 'pPos');
+final pZero = state<int>((n) => n == 0, name: 'pZero');
+final pTrue = state<int>((_) => true, name: 'pTrue');
+final pFalse = state<int>((_) => false, name: 'pFalse');
+
+const stateValues = [-2, -1, 0, 1, 2];
+
+// Pre-computed depth-0 formulas
+final List<Formula<int>> depth0Formulas = [pEven, pPos, pZero, pTrue, pFalse];
+
+// Pre-computed depth-1 formulas
+final List<Formula<int>> depth1Formulas = _buildDepth1();
+
+List<Formula<int>> _buildDepth1() {
+  final result = <Formula<int>>[...depth0Formulas];
+  for (final f in depth0Formulas) {
+    result.addAll([Not(f), Always(f), Eventually(f), Next(f)]);
+  }
+  for (final f1 in depth0Formulas) {
+    for (final f2 in depth0Formulas) {
+      result.addAll([
+        And(f1, f2),
+        Or(f1, f2),
+        Implies(f1, f2),
+        Until(f1, f2),
+        WeakUntil(f1, f2),
+        Release(f1, f2),
+      ]);
+    }
+  }
+  return result;
+}
+
+Formula<int> _buildFromOp(int op, Formula<int> f1, Formula<int> f2) {
+  switch (op % 10) {
+    case 0:
+      return Not(f1);
+    case 1:
+      return And(f1, f2);
+    case 2:
+      return Or(f1, f2);
+    case 3:
+      return Implies(f1, f2);
+    case 4:
+      return Next(f1);
+    case 5:
+      return Always(f1);
+    case 6:
+      return Eventually(f1);
+    case 7:
+      return Until(f1, f2);
+    case 8:
+      return WeakUntil(f1, f2);
+    case 9:
+      return Release(f1, f2);
+    default:
+      return f1;
+  }
+}
+
+extension TemporalLogicGenerators on Any {
+  /// Trace<int> with 0-5 events, values from stateValues,
+  /// sorted timestamps with small gaps (0-10ms).
+  Generator<Trace<int>> get traceOfInt => combine2(
+        listWithLengthInRange(0, 6, choose(stateValues)),
+        listWithLengthInRange(0, 5, intInRange(0, 11)),
+        (List<int> values, List<int> gaps) {
+          if (values.isEmpty) return Trace<int>.empty();
+          final events = <TraceEvent<int>>[];
+          var ts = Duration.zero;
+          for (var i = 0; i < values.length; i++) {
+            if (i > 0 && i - 1 < gaps.length) {
+              ts += Duration(milliseconds: gaps[i - 1]);
+            }
+            events.add(TraceEvent(timestamp: ts, value: values[i]));
+          }
+          return Trace(events);
+        },
+      );
+
+  /// Depth-0 formula (atom)
+  Generator<Formula<int>> get atomFormula => choose(depth0Formulas);
+
+  /// Depth-1 formula (pre-computed pool)
+  Generator<Formula<int>> get d1Formula => choose(depth1Formulas);
+
+  /// Depth-2 formula (compose depth-1 with random operator)
+  Generator<Formula<int>> get d2Formula => combine3(
+        intInRange(0, 10),
+        choose(depth1Formulas),
+        choose(depth1Formulas),
+        _buildFromOp,
+      );
+
+  /// Pure LTL formula (no MTL nodes) — same as d2Formula for core
+  Generator<Formula<int>> get pureLtlFormula => d2Formula;
+
+  /// Start index: 0..5 (covers trace.length for traces up to 5)
+  Generator<int> get startIdx => choose([0, 1, 2, 3, 4, 5]);
+}

--- a/packages/temporal_logic_core/test/generators.dart
+++ b/packages/temporal_logic_core/test/generators.dart
@@ -64,7 +64,7 @@ Formula<int> _buildFromOp(int op, Formula<int> f1, Formula<int> f2) {
     case 9:
       return Release(f1, f2);
     default:
-      return f1;
+      throw StateError('unreachable: op % 10 covers 0-9');
   }
 }
 

--- a/packages/temporal_logic_core/test/generators.dart
+++ b/packages/temporal_logic_core/test/generators.dart
@@ -79,6 +79,8 @@ extension TemporalLogicGenerators on Any {
           final events = <TraceEvent<int>>[];
           var ts = Duration.zero;
           for (var i = 0; i < values.length; i++) {
+            // When values outnumber gaps, remaining events share the last
+            // timestamp — this is intentional to exercise concurrent-event paths.
             if (i > 0 && i - 1 < gaps.length) {
               ts += Duration(milliseconds: gaps[i - 1]);
             }

--- a/packages/temporal_logic_core/test/pbt_properties_test.dart
+++ b/packages/temporal_logic_core/test/pbt_properties_test.dart
@@ -1,0 +1,181 @@
+import 'package:glados/glados.dart';
+import 'package:temporal_logic_core/temporal_logic_core.dart';
+
+import 'generators.dart';
+import 'reference_evaluator.dart';
+
+void main() {
+  final config = ExploreConfig(numRuns: 200, initialSize: 5, speed: 1);
+
+  group('Duality Laws', () {
+    // 1. G(p) == !F(!p)
+    Glados2(any.traceOfInt, any.d1Formula, config).test(
+      'G(p) == !F(!p)',
+      (trace, p) {
+        for (var si = 0; si <= trace.length; si++) {
+          final gp = evaluateTrace(trace, Always(p), startIndex: si).holds;
+          final nfnp =
+              evaluateTrace(trace, Not(Eventually(Not(p))), startIndex: si)
+                  .holds;
+          expect(gp, equals(nfnp),
+              reason: 'G($p) != !F(!$p) at index $si on $trace');
+        }
+      },
+    );
+
+    // 2. F(p) == !G(!p)
+    Glados2(any.traceOfInt, any.d1Formula, config).test(
+      'F(p) == !G(!p)',
+      (trace, p) {
+        for (var si = 0; si <= trace.length; si++) {
+          final fp = evaluateTrace(trace, Eventually(p), startIndex: si).holds;
+          final ngnp =
+              evaluateTrace(trace, Not(Always(Not(p))), startIndex: si).holds;
+          expect(fp, equals(ngnp),
+              reason: 'F($p) != !G(!$p) at index $si on $trace');
+        }
+      },
+    );
+
+    // 3. R(p,q) == !(!p U !q)
+    Glados3(any.traceOfInt, any.atomFormula, any.atomFormula, config).test(
+      'R(p,q) == !(!p U !q)',
+      (trace, p, q) {
+        for (var si = 0; si <= trace.length; si++) {
+          final rpq =
+              evaluateTrace(trace, Release(p, q), startIndex: si).holds;
+          final dual =
+              evaluateTrace(trace, Not(Until(Not(p), Not(q))), startIndex: si)
+                  .holds;
+          expect(rpq, equals(dual),
+              reason: 'R($p,$q) != !(!$p U !$q) at index $si on $trace');
+        }
+      },
+    );
+
+    // 4. W(p,q) == G(p) || (p U q)
+    Glados3(any.traceOfInt, any.atomFormula, any.atomFormula, config).test(
+      'W(p,q) == G(p) || (p U q)',
+      (trace, p, q) {
+        for (var si = 0; si <= trace.length; si++) {
+          final wpq =
+              evaluateTrace(trace, WeakUntil(p, q), startIndex: si).holds;
+          final dual =
+              evaluateTrace(trace, Or(Always(p), Until(p, q)), startIndex: si)
+                  .holds;
+          expect(wpq, equals(dual),
+              reason: 'W($p,$q) != G($p)||($p U $q) at index $si on $trace');
+        }
+      },
+    );
+
+    // 5. Double negation (involution): !!p == p
+    Glados2(any.traceOfInt, any.d1Formula, config).test(
+      '!!p == p (involution)',
+      (trace, p) {
+        for (var si = 0; si <= trace.length; si++) {
+          final pHolds = evaluateTrace(trace, p, startIndex: si).holds;
+          final nnp = evaluateTrace(trace, Not(Not(p)), startIndex: si).holds;
+          expect(nnp, equals(pHolds),
+              reason: '!!($p) != $p at index $si on $trace');
+        }
+      },
+    );
+  });
+
+  group('Reference Model', () {
+    // 6. Release: evaluator matches naive implementation
+    Glados3(any.traceOfInt, any.atomFormula, any.atomFormula, config).test(
+      'Release matches naive reference',
+      (trace, p, q) {
+        for (var si = 0; si <= trace.length; si++) {
+          final evalResult =
+              evaluateTrace(trace, Release(p, q), startIndex: si).holds;
+          final naiveResult = naiveRelease(trace, p, q, si);
+          expect(evalResult, equals(naiveResult),
+              reason:
+                  'Release($p,$q) evaluator vs naive at index $si on $trace');
+        }
+      },
+    );
+
+    // 7. WeakUntil: evaluator matches naive implementation
+    Glados3(any.traceOfInt, any.atomFormula, any.atomFormula, config).test(
+      'WeakUntil matches naive reference',
+      (trace, p, q) {
+        for (var si = 0; si <= trace.length; si++) {
+          final evalResult =
+              evaluateTrace(trace, WeakUntil(p, q), startIndex: si).holds;
+          final naiveResult = naiveWeakUntil(trace, p, q, si);
+          expect(evalResult, equals(naiveResult),
+              reason:
+                  'WeakUntil($p,$q) evaluator vs naive at index $si on $trace');
+        }
+      },
+    );
+  });
+
+  group('Metamorphic Properties', () {
+    // 8. Suffix normalization: eval(trace, phi, i) == eval(suffix(i), phi, 0)
+    Glados2(any.traceOfInt, any.d1Formula, config).test(
+      'suffix normalization',
+      (trace, phi) {
+        for (var si = 0; si <= trace.length; si++) {
+          final direct = evaluateTrace(trace, phi, startIndex: si).holds;
+          // Create suffix trace starting at index si
+          final suffixEvents = trace.events.sublist(si);
+          // Adjust timestamps: subtract the base timestamp
+          final baseTs =
+              suffixEvents.isNotEmpty ? suffixEvents.first.timestamp : Duration.zero;
+          final adjustedEvents = suffixEvents
+              .map((e) =>
+                  TraceEvent(timestamp: e.timestamp - baseTs, value: e.value))
+              .toList();
+          final suffixTrace = Trace(adjustedEvents);
+          final viaSuffix = evaluateTrace(suffixTrace, phi, startIndex: 0).holds;
+          expect(direct, equals(viaSuffix),
+              reason:
+                  'eval($phi, si=$si) != eval(suffix, 0) on $trace');
+        }
+      },
+    );
+
+    // 9. Determinism: same inputs always produce same result
+    Glados2(any.traceOfInt, any.d2Formula, config).test(
+      'determinism',
+      (trace, formula) {
+        for (var si = 0; si <= trace.length; si++) {
+          final r1 = evaluateTrace(trace, formula, startIndex: si).holds;
+          final r2 = evaluateTrace(trace, formula, startIndex: si).holds;
+          expect(r1, equals(r2),
+              reason: 'Non-deterministic result for $formula at $si on $trace');
+        }
+      },
+    );
+  });
+
+  group('Invariants', () {
+    // 10. Vacuous truth: G(p) on empty suffix is true, F(p) is false
+    Glados(any.d1Formula, config).test(
+      'vacuous truth on empty trace',
+      (p) {
+        final emptyTrace = Trace<int>.empty();
+        expect(evaluateTrace(emptyTrace, Always(p)).holds, isTrue,
+            reason: 'G($p) should be vacuously true on empty trace');
+        expect(evaluateTrace(emptyTrace, Eventually(p)).holds, isFalse,
+            reason: 'F($p) should be false on empty trace');
+      },
+    );
+
+    // 11. No crash on any valid trace/formula/startIndex combination
+    Glados2(any.traceOfInt, any.d2Formula, config).test(
+      'no crash on valid inputs',
+      (trace, formula) {
+        for (var si = 0; si <= trace.length; si++) {
+          final result = evaluateTrace(trace, formula, startIndex: si);
+          expect(result, isA<EvaluationResult>());
+        }
+      },
+    );
+  });
+}

--- a/packages/temporal_logic_core/test/reference_evaluator.dart
+++ b/packages/temporal_logic_core/test/reference_evaluator.dart
@@ -1,0 +1,33 @@
+import 'package:temporal_logic_core/temporal_logic_core.dart';
+
+/// Naive recursive implementation of Release that does NOT use duality rewrite.
+///
+/// p R q at i:
+///   if i >= trace.length: true (vacuously)
+///   q holds at i, AND (p holds at i OR p R q at i+1)
+bool naiveRelease(
+    Trace<int> trace, Formula<int> p, Formula<int> q, int startIndex) {
+  if (startIndex >= trace.length) return true;
+  final qHolds = evaluateTrace(trace, q, startIndex: startIndex).holds;
+  if (!qHolds) return false;
+  final pHolds = evaluateTrace(trace, p, startIndex: startIndex).holds;
+  if (pHolds) return true;
+  return naiveRelease(trace, p, q, startIndex + 1);
+}
+
+/// Naive recursive implementation of WeakUntil that does NOT use duality rewrite.
+///
+/// p W q at i:
+///   if i >= trace.length: true (vacuously, G(p) on empty suffix)
+///   q holds at i: true (U terminates immediately)
+///   p holds at i: check p W q at i+1
+///   otherwise: false
+bool naiveWeakUntil(
+    Trace<int> trace, Formula<int> p, Formula<int> q, int startIndex) {
+  if (startIndex >= trace.length) return true;
+  final qHolds = evaluateTrace(trace, q, startIndex: startIndex).holds;
+  if (qHolds) return true;
+  final pHolds = evaluateTrace(trace, p, startIndex: startIndex).holds;
+  if (!pHolds) return false;
+  return naiveWeakUntil(trace, p, q, startIndex + 1);
+}

--- a/packages/temporal_logic_mtl/pubspec.yaml
+++ b/packages/temporal_logic_mtl/pubspec.yaml
@@ -20,5 +20,6 @@ dependencies:
 dev_dependencies:
   lints: ^5.1.1 # Align with temporal_logic_flutter
   test: ^1.24.0 # Test framework
+  glados: ^1.1.7
 
 resolution: workspace

--- a/packages/temporal_logic_mtl/test/generators.dart
+++ b/packages/temporal_logic_mtl/test/generators.dart
@@ -1,0 +1,189 @@
+import 'package:glados/glados.dart';
+import 'package:temporal_logic_mtl/temporal_logic_mtl.dart';
+
+// Re-use core atoms
+final pEven = state<int>((n) => n % 2 == 0, name: 'pEven');
+final pPos = state<int>((n) => n > 0, name: 'pPos');
+final pZero = state<int>((n) => n == 0, name: 'pZero');
+final pTrue = state<int>((_) => true, name: 'pTrue');
+final pFalse = state<int>((_) => false, name: 'pFalse');
+
+const stateValues = [-2, -1, 0, 1, 2];
+
+final List<Formula<int>> depth0Formulas = [pEven, pPos, pZero, pTrue, pFalse];
+
+// Pure LTL depth-1 formulas (no timed operators)
+final List<Formula<int>> pureLtlDepth1 = _buildPureLtlDepth1();
+
+List<Formula<int>> _buildPureLtlDepth1() {
+  final result = <Formula<int>>[...depth0Formulas];
+  for (final f in depth0Formulas) {
+    result.addAll([Not(f), Always(f), Eventually(f), Next(f)]);
+  }
+  for (final f1 in depth0Formulas) {
+    for (final f2 in depth0Formulas) {
+      result.addAll([
+        And(f1, f2),
+        Or(f1, f2),
+        Implies(f1, f2),
+        Until(f1, f2),
+        WeakUntil(f1, f2),
+        Release(f1, f2),
+      ]);
+    }
+  }
+  return result;
+}
+
+Formula<int> _buildFromOp(int op, Formula<int> f1, Formula<int> f2) {
+  switch (op % 10) {
+    case 0:
+      return Not(f1);
+    case 1:
+      return And(f1, f2);
+    case 2:
+      return Or(f1, f2);
+    case 3:
+      return Implies(f1, f2);
+    case 4:
+      return Next(f1);
+    case 5:
+      return Always(f1);
+    case 6:
+      return Eventually(f1);
+    case 7:
+      return Until(f1, f2);
+    case 8:
+      return WeakUntil(f1, f2);
+    case 9:
+      return Release(f1, f2);
+    default:
+      return f1;
+  }
+}
+
+Formula<int> _buildTimedFormula(
+    int op, Formula<int> f1, Formula<int> f2, TimeInterval iv) {
+  switch (op) {
+    case 0:
+      return EventuallyTimed(f1, iv);
+    case 1:
+      return AlwaysTimed(f1, iv);
+    case 2:
+      return UntilTimed(f1, f2, iv);
+    case 3:
+      return ReleaseTimed(f1, f2, iv);
+    case 4:
+      return WeakUntilTimed(f1, f2, iv);
+    default:
+      return EventuallyTimed(f1, iv);
+  }
+}
+
+extension MtlGenerators on Any {
+  /// Trace<int> with 0-5 events and realistic timestamps (gaps 0-10ms).
+  Generator<Trace<int>> get traceOfInt => combine2(
+        listWithLengthInRange(0, 6, choose(stateValues)),
+        listWithLengthInRange(0, 5, intInRange(0, 11)),
+        (List<int> values, List<int> gaps) {
+          if (values.isEmpty) return Trace<int>.empty();
+          final events = <TraceEvent<int>>[];
+          var ts = Duration.zero;
+          for (var i = 0; i < values.length; i++) {
+            if (i > 0 && i - 1 < gaps.length) {
+              ts += Duration(milliseconds: gaps[i - 1]);
+            }
+            events.add(TraceEvent(timestamp: ts, value: values[i]));
+          }
+          return Trace(events);
+        },
+      );
+
+  /// TimeInterval with lb <= ub, scaled to plausible trace spans (0-50ms).
+  Generator<TimeInterval> get timeInterval => combine2(
+        intInRange(0, 51),
+        intInRange(0, 51),
+        (int lb, int ubOffset) {
+          return TimeInterval(
+            Duration(milliseconds: lb),
+            Duration(milliseconds: lb + ubOffset),
+          );
+        },
+      );
+
+  /// TimeInterval derived from the given trace's actual timestamp span.
+  Generator<TimeInterval> traceRelativeInterval(Trace<int> trace) {
+    final spanMs = trace.events.length < 2
+        ? 10
+        : (trace.events.last.timestamp - trace.events.first.timestamp)
+                .inMilliseconds +
+            1;
+    return combine2(
+      intInRange(0, spanMs + 1),
+      intInRange(0, spanMs + 1),
+      (int a, int b) {
+        final lb = a < b ? a : b;
+        final ub = a < b ? b : a;
+        return TimeInterval(
+          Duration(milliseconds: lb),
+          Duration(milliseconds: ub),
+        );
+      },
+    );
+  }
+
+  /// Depth-0 formula (atom)
+  Generator<Formula<int>> get atomFormula => choose(depth0Formulas);
+
+  /// Pure LTL depth-1 formula
+  Generator<Formula<int>> get pureLtlD1 => choose(pureLtlDepth1);
+
+  /// Pure LTL depth-2 formula
+  Generator<Formula<int>> get pureLtlD2 => combine3(
+        intInRange(0, 10),
+        choose(pureLtlDepth1),
+        choose(pureLtlDepth1),
+        _buildFromOp,
+      );
+
+  /// Timed formula: wraps atoms with timed operators and random intervals.
+  Generator<Formula<int>> get timedFormula => combine4(
+        choose([0, 1, 2, 3, 4]),
+        atomFormula,
+        atomFormula,
+        timeInterval,
+        _buildTimedFormula,
+      );
+
+  /// Depth-2 timed formula: wraps LTL depth-1 subformulas with timed operators.
+  Generator<Formula<int>> get timedD2Formula => combine4(
+        choose([0, 1, 2, 3, 4]),
+        pureLtlD1,
+        pureLtlD1,
+        timeInterval,
+        _buildTimedFormula,
+      );
+
+  /// Nested timed formula: timed operator over timed subformulas (depth-2 timed).
+  /// Produces shapes like G_I(F_J(p)), U_I(p, R_J(q, r)), etc.
+  Generator<Formula<int>> get nestedTimedFormula => combine4(
+        choose([0, 1, 2, 3, 4]),
+        timedFormula,
+        timedFormula,
+        timeInterval,
+        _buildTimedFormula,
+      );
+
+  /// Trace paired with a trace-relative interval (dependent generation).
+  Generator<(Trace<int>, TimeInterval)> get traceWithRelativeInterval =>
+      traceOfInt.bind(
+        (trace) => traceRelativeInterval(trace).map((iv) => (trace, iv)),
+      );
+
+  /// Start index dependent on trace length (avoids clamp bias).
+  Generator<int> startIdxFor(Trace<int> trace) =>
+      intInRange(0, trace.length + 1);
+
+  /// Start index: 0..5
+  Generator<int> get startIdx => choose([0, 1, 2, 3, 4, 5]);
+}

--- a/packages/temporal_logic_mtl/test/generators.dart
+++ b/packages/temporal_logic_mtl/test/generators.dart
@@ -102,7 +102,7 @@ extension MtlGenerators on Any {
         },
       );
 
-  /// TimeInterval with lb <= ub, scaled to plausible trace spans (0-50ms).
+  /// TimeInterval with lb <= ub, lb in 0-50ms, ub in lb..(lb+50)ms.
   Generator<TimeInterval> get timeInterval => combine2(
         intInRange(0, 51),
         intInRange(0, 51),

--- a/packages/temporal_logic_mtl/test/generators.dart
+++ b/packages/temporal_logic_mtl/test/generators.dart
@@ -1,7 +1,8 @@
 import 'package:glados/glados.dart';
 import 'package:temporal_logic_mtl/temporal_logic_mtl.dart';
 
-// Re-use core atoms
+// Intentionally duplicated from core/test/generators.dart for test isolation.
+// Test files are not exported across packages, so sharing is not possible.
 final pEven = state<int>((n) => n % 2 == 0, name: 'pEven');
 final pPos = state<int>((n) => n > 0, name: 'pPos');
 final pZero = state<int>((n) => n == 0, name: 'pZero');
@@ -90,6 +91,8 @@ extension MtlGenerators on Any {
           final events = <TraceEvent<int>>[];
           var ts = Duration.zero;
           for (var i = 0; i < values.length; i++) {
+            // When values outnumber gaps, remaining events share the last
+            // timestamp — this is intentional to exercise concurrent-event paths.
             if (i > 0 && i - 1 < gaps.length) {
               ts += Duration(milliseconds: gaps[i - 1]);
             }

--- a/packages/temporal_logic_mtl/test/generators.dart
+++ b/packages/temporal_logic_mtl/test/generators.dart
@@ -59,7 +59,7 @@ Formula<int> _buildFromOp(int op, Formula<int> f1, Formula<int> f2) {
     case 9:
       return Release(f1, f2);
     default:
-      return f1;
+      throw StateError('unreachable: op % 10 covers 0-9');
   }
 }
 
@@ -77,7 +77,7 @@ Formula<int> _buildTimedFormula(
     case 4:
       return WeakUntilTimed(f1, f2, iv);
     default:
-      return EventuallyTimed(f1, iv);
+      throw StateError('unreachable: callers use choose([0..4])');
   }
 }
 

--- a/packages/temporal_logic_mtl/test/pbt_properties_test.dart
+++ b/packages/temporal_logic_mtl/test/pbt_properties_test.dart
@@ -1,0 +1,268 @@
+import 'package:glados/glados.dart';
+import 'package:temporal_logic_core/temporal_logic_core.dart' as core;
+import 'package:temporal_logic_mtl/temporal_logic_mtl.dart';
+
+import 'generators.dart';
+
+void main() {
+  final config = ExploreConfig(numRuns: 200, initialSize: 5, speed: 1);
+
+  group('Timed Duality Laws', () {
+    // 1. G_I(p) == !F_I(!p)
+    Glados3(any.traceOfInt, any.atomFormula, any.timeInterval, config).test(
+      'G_I(p) == !F_I(!p)',
+      (trace, p, interval) {
+        for (var si = 0; si <= trace.length; si++) {
+          final gip =
+              evaluateMtlTrace(trace, AlwaysTimed(p, interval), startIndex: si)
+                  .holds;
+          final nfinp = evaluateMtlTrace(
+                  trace, Not(EventuallyTimed(Not(p), interval)),
+                  startIndex: si)
+              .holds;
+          expect(gip, equals(nfinp),
+              reason:
+                  'G_$interval($p) != !F_$interval(!$p) at si=$si on $trace');
+        }
+      },
+    );
+
+    // 2. R_I(p,q) == !(!p U_I !q)
+    Glados(
+      any.combine4(
+        any.traceOfInt,
+        any.atomFormula,
+        any.atomFormula,
+        any.timeInterval,
+        (Trace<int> t, Formula<int> p, Formula<int> q, TimeInterval iv) =>
+            (t, p, q, iv),
+      ),
+      config,
+    ).test(
+      'R_I(p,q) == !(!p U_I !q)',
+      (input) {
+        final (trace, p, q, interval) = input;
+        for (var si = 0; si <= trace.length; si++) {
+          final rip = evaluateMtlTrace(
+                  trace, ReleaseTimed(p, q, interval),
+                  startIndex: si)
+              .holds;
+          final dual = evaluateMtlTrace(
+                  trace, Not(UntilTimed(Not(p), Not(q), interval)),
+                  startIndex: si)
+              .holds;
+          expect(rip, equals(dual),
+              reason:
+                  'R_$interval($p,$q) != !(!$p U_$interval !$q) at si=$si on $trace');
+        }
+      },
+    );
+
+    // 3. W_I(p,q) == G_I(p) || (p U_I q)
+    Glados(
+      any.combine4(
+        any.traceOfInt,
+        any.atomFormula,
+        any.atomFormula,
+        any.timeInterval,
+        (Trace<int> t, Formula<int> p, Formula<int> q, TimeInterval iv) =>
+            (t, p, q, iv),
+      ),
+      config,
+    ).test(
+      'W_I(p,q) == G_I(p) || (p U_I q)',
+      (input) {
+        final (trace, p, q, interval) = input;
+        for (var si = 0; si <= trace.length; si++) {
+          final wip = evaluateMtlTrace(
+                  trace, WeakUntilTimed(p, q, interval),
+                  startIndex: si)
+              .holds;
+          final dual = evaluateMtlTrace(
+                  trace,
+                  Or(AlwaysTimed(p, interval), UntilTimed(p, q, interval)),
+                  startIndex: si)
+              .holds;
+          expect(wip, equals(dual),
+              reason:
+                  'W_$interval($p,$q) != G_$interval($p)||($p U_$interval $q) at si=$si on $trace');
+        }
+      },
+    );
+  });
+
+  group('Timed Duality Laws (trace-relative intervals)', () {
+    // G_I(p) == !F_I(!p) with intervals derived from actual trace span
+    Glados2(any.traceWithRelativeInterval, any.atomFormula, config).test(
+      'G_I(p) == !F_I(!p) (trace-relative)',
+      (pair, p) {
+        final (trace, interval) = pair;
+        for (var si = 0; si <= trace.length; si++) {
+          final gip =
+              evaluateMtlTrace(trace, AlwaysTimed(p, interval), startIndex: si)
+                  .holds;
+          final nfinp = evaluateMtlTrace(
+                  trace, Not(EventuallyTimed(Not(p), interval)),
+                  startIndex: si)
+              .holds;
+          expect(gip, equals(nfinp),
+              reason:
+                  'G_$interval($p) != !F_$interval(!$p) at si=$si on $trace');
+        }
+      },
+    );
+  });
+
+  group('Core/MTL Parity', () {
+    // 4. Pure LTL formulas: core evaluator == MTL evaluator
+    Glados2(any.traceOfInt, any.pureLtlD2, config).test(
+      'evaluateTrace == evaluateMtlTrace for pure LTL',
+      (trace, formula) {
+        for (var si = 0; si <= trace.length; si++) {
+          final coreResult =
+              core.evaluateTrace(trace, formula, startIndex: si).holds;
+          final mtlResult =
+              evaluateMtlTrace(trace, formula, startIndex: si).holds;
+          expect(coreResult, equals(mtlResult),
+              reason:
+                  'Core vs MTL mismatch for $formula at si=$si on $trace');
+        }
+      },
+    );
+  });
+
+  group('Metamorphic Properties', () {
+    // 5. Time-translation invariance: shifting all timestamps by constant c
+    //    doesn't change .holds for timed formulas (intervals are relative).
+    Glados2(any.traceOfInt, any.timedD2Formula, config).test(
+      'time-translation invariance (timed formulas)',
+      (trace, formula) {
+        const shift = Duration(milliseconds: 100);
+        final shiftedEvents = trace.events
+            .map((e) =>
+                TraceEvent(timestamp: e.timestamp + shift, value: e.value))
+            .toList();
+        final shiftedTrace = Trace(shiftedEvents);
+        for (var si = 0; si <= trace.length; si++) {
+          final original =
+              evaluateMtlTrace(trace, formula, startIndex: si).holds;
+          final shifted =
+              evaluateMtlTrace(shiftedTrace, formula, startIndex: si).holds;
+          expect(original, equals(shifted),
+              reason:
+                  'Time-translation changed result for $formula at si=$si');
+        }
+      },
+    );
+
+    // 6. Suffix normalization for timed formulas:
+    //    eval(trace, phi, i) == eval(suffix(i), phi, 0)
+    Glados2(any.traceOfInt, any.timedD2Formula, config).test(
+      'suffix normalization (timed formulas)',
+      (trace, phi) {
+        for (var si = 0; si <= trace.length; si++) {
+          final direct =
+              evaluateMtlTrace(trace, phi, startIndex: si).holds;
+          final suffixEvents = trace.events.sublist(si);
+          final baseTs = suffixEvents.isNotEmpty
+              ? suffixEvents.first.timestamp
+              : Duration.zero;
+          final adjustedEvents = suffixEvents
+              .map((e) =>
+                  TraceEvent(timestamp: e.timestamp - baseTs, value: e.value))
+              .toList();
+          final suffixTrace = Trace(adjustedEvents);
+          final viaSuffix =
+              evaluateMtlTrace(suffixTrace, phi, startIndex: 0).holds;
+          expect(direct, equals(viaSuffix),
+              reason:
+                  'eval($phi, si=$si) != eval(suffix, 0) on $trace');
+        }
+      },
+    );
+
+    // 7. Interval monotonicity:
+    //    I ⊆ J → F_I(p).holds → F_J(p).holds
+    //    I ⊆ J → G_J(p).holds → G_I(p).holds
+    Glados(
+      any.combine4(
+        any.traceOfInt,
+        any.atomFormula,
+        any.timeInterval,
+        any.choose([0, 1, 2, 5, 10, 50]),
+        (Trace<int> t, Formula<int> p, TimeInterval inner, int expansion) =>
+            (t, p, inner, expansion),
+      ),
+      config,
+    ).test(
+      'interval monotonicity',
+      (input) {
+        final (trace, p, inner, expansion) = input;
+        // Build outer interval: expand inner by `expansion` ms on each side
+        final outerLb = inner.lowerBound - Duration(milliseconds: expansion);
+        final effectiveLb =
+            outerLb.isNegative ? Duration.zero : outerLb;
+        final outer = TimeInterval(
+          effectiveLb,
+          inner.upperBound + Duration(milliseconds: expansion),
+        );
+
+        for (var si = 0; si <= trace.length; si++) {
+          // F_I(p) → F_J(p) (inner ⊆ outer)
+          final fInner = evaluateMtlTrace(
+                  trace, EventuallyTimed(p, inner),
+                  startIndex: si)
+              .holds;
+          final fOuter = evaluateMtlTrace(
+                  trace, EventuallyTimed(p, outer),
+                  startIndex: si)
+              .holds;
+          if (fInner) {
+            expect(fOuter, isTrue,
+                reason:
+                    'F_$inner($p) true but F_$outer($p) false at si=$si');
+          }
+
+          // G_J(p) → G_I(p) (inner ⊆ outer)
+          final gOuter = evaluateMtlTrace(
+                  trace, AlwaysTimed(p, outer),
+                  startIndex: si)
+              .holds;
+          final gInner = evaluateMtlTrace(
+                  trace, AlwaysTimed(p, inner),
+                  startIndex: si)
+              .holds;
+          if (gOuter) {
+            expect(gInner, isTrue,
+                reason:
+                    'G_$outer($p) true but G_$inner($p) false at si=$si');
+          }
+        }
+      },
+    );
+  });
+
+  group('Robustness', () {
+    // No crash on any valid trace/timedD2Formula/startIndex combination
+    Glados2(any.traceOfInt, any.timedD2Formula, config).test(
+      'no crash on timed formula inputs',
+      (trace, formula) {
+        for (var si = 0; si <= trace.length; si++) {
+          final result = evaluateMtlTrace(trace, formula, startIndex: si);
+          expect(result, isA<EvaluationResult>());
+        }
+      },
+    );
+
+    // No crash on nested timed formulas (timed-over-timed)
+    Glados2(any.traceOfInt, any.nestedTimedFormula, config).test(
+      'no crash on nested timed formula inputs',
+      (trace, formula) {
+        for (var si = 0; si <= trace.length; si++) {
+          final result = evaluateMtlTrace(trace, formula, startIndex: si);
+          expect(result, isA<EvaluationResult>());
+        }
+      },
+    );
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -131,6 +131,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  glados:
+    dependency: transitive
+    description:
+      name: glados
+      sha256: c39446c0c4fe83a6ee6ee4fdee5a1afa27050619c7df390bf4c3b77b6f1acb33
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.7"
   glob:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Add systematic property-based testing (PBT) using `glados` to verify algebraic invariants, reference model correctness, and metamorphic properties across both core LTL and MTL evaluators. 21 property tests with 200 random inputs each (4,200 total property checks).

## Why

- **Goal**: Catch subtle evaluator bugs that hand-written tests miss by exhaustively exploring the input space of formulas, traces, and start indices
- **Reason**: Duality laws (G=!F!, R=!U!) and metamorphic properties (suffix normalization, time-translation invariance) are mathematical identities that must hold for *all* inputs — PBT is the natural verification approach
- **Alternatives**: (1) More hand-written edge cases — rejected: scales linearly with effort, can't cover the combinatorial space. (2) Model checking — rejected: overkill for finite-trace semantics with small state domain

## What Changed

**New files (5)**:
- `core/test/generators.dart` — Shared PBT generators: traces (0-5 events, signed int domain {-2..2}), depth-0/1/2 formula pools (5 atoms including pTrue/pFalse, 10 LTL operators), gap-based timestamp generation
- `core/test/reference_evaluator.dart` — Naive recursive Release/WeakUntil implementations independent of duality rewrites (operator-local oracle)
- `core/test/pbt_properties_test.dart` — 11 core PBT properties
- `mtl/test/generators.dart` — MTL-specific generators: TimeInterval, trace-relative intervals (`.bind()` dependent generation), timed/timedD2/nestedTimed formula generators
- `mtl/test/pbt_properties_test.dart` — 10 MTL PBT properties

**Modified files (3)**:
- `core/test/evaluator_test.dart` — +162 lines: nested Until, Release combinations, deeply nested temporal, mixed binary operator tests
- `core/pubspec.yaml`, `mtl/pubspec.yaml` — Added `glados: ^1.1.7` dev dependency

**Behavior unchanged**: No production code modified. All existing tests continue to pass.

## Blast Radius

- **Affected**: Test files only (`test/` directories in core and mtl packages)
- **Compatibility**: No API changes. Dev dependency addition (`glados`) does not affect consumers

## Invariants (Must Stay True)

| Condition | Evidence | Symptom if Broken |
|-----------|----------|-------------------|
| `G(p) ≡ ¬F(¬p)` for all traces, formulas, start indices | PBT: 200 random inputs × all startIndex values | Evaluator returns wrong boolean for Always/Eventually |
| `R(p,q) ≡ ¬(¬p U ¬q)` for both untimed and timed variants | PBT + naive reference model cross-check | Release operator semantics incorrect |
| `eval(trace, φ, i) ≡ eval(suffix(i), φ, 0)` | Suffix normalization PBT (core + MTL) | startIndex-dependent evaluation bugs |

## Failure Modes

| Type | Pattern | Detection |
|------|---------|-----------|
| Likely | Generator bias produces vacuous test cases (e.g., interval >> trace span) | Mitigated: trace-relative interval generator, interval range scaled to 0-100ms |
| Critical | Reference evaluator has same bug as production (shared subformula delegation) | Mitigated: reference model only wraps atomic sub-evaluations; duality tests provide independent second check |
| Hard to notice | pTrue/pFalse atoms inflate depth-1 pool, reducing effective formula diversity | Monitored: formula pool size is bounded; 200 runs with multiple generators covers reasonable space |

## Evidence

- [x] `dart analyze` — 0 issues on all PBT files (verified after each iteration)
- [x] `dart test test/` (core) — 94 passed, ~1 skipped
- [x] `dart test test/` (mtl) — 412 passed
- [x] 5 rounds of critical code review with Codex (gpt-5.4, xhigh reasoning): final round found 0 bugs
- Fixes applied across iterations: unused imports, time-translation test scope, interval range scaling, nested timed generators, suffix normalization for MTL, clamp bias elimination

## Rollout & Rollback

- **Rollout**: Merge to main. No deployment needed — test-only changes
- **Rollback**: `git revert <commit>`. Safe: no production code affected
- **Cannot rollback if**: N/A (test-only)

## Review Focus

- [ ] `core/test/reference_evaluator.dart` — Is the naive Release/WeakUntil correct per finite-trace LTL semantics?
- [ ] `mtl/test/generators.dart:traceRelativeInterval` — Does `.bind()` dependent generation properly derive intervals from trace span?
- [ ] `mtl/test/pbt_properties_test.dart:suffix normalization` — Is timestamp renormalization correct for timed formulas?

## Unknowns

| Item | Resolution | Blocker? |
|------|-----------|----------|
| Generator atom space correlation (5 truth patterns, not 8 independent) | Accept for now; move to bitmask state if false negatives found | No |
| Code duplication between core/mtl generators | Extract to shared test_support package in future PR | No |

## Related

- Issue: #2 (Add comprehensive test coverage)
- Prior work: `mtl_operators_test.dart`, `semantics_matrix_test.dart` (hand-written coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * LTL/MTL 向けの包括的なプロパティベーステストを大幅追加（ネスト・組合せ・境界・バグ再現ケース含む）。
  * ランダム生成器と多層の式プールを導入し、双対性・参照実装比較・接尾辞正規化・時間的性質・決定性・安定性などを検証。
  * 参照的ナイーブ実装との比較テストを追加し堅牢性を強化。

* **Chores**
  * 開発用テストフレームワークの dev 依存を追加しました（複数パッケージ）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->